### PR TITLE
README: enable syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,72 +10,76 @@ It also has some additional benefits such as providing easy access to informatio
 
 Using this middleware requires a couple of additions to your code. First, the host builder must be modified(typically in your `Program.cs` file), adding a call to `UseScalewayFunctions()`. A simple `Program.cs` might look like
 
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.Hosting;
+```cs
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
-    namespace Scaleway.Functions
+namespace Scaleway.Functions
+{
+    public class Program
     {
-        public class Program
+        public static void Main(string[] args)
         {
-            public static void Main(string[] args)
-            {
-                CreateHostBuilder(args).Build().Run();
-            }
-
-            public static IHostBuilder CreateHostBuilder(string[] args) =>
-                Host.CreateDefaultBuilder(args)
-                    .ConfigureWebHostDefaults(webBuilder =>
-                    {
-                        webBuilder
-                            // Make sure Kestrel listens on the correct port.
-                            .UseScalewayFunctionsHosting()
-                            .UseStartup<Startup>();
-                    });
+            CreateHostBuilder(args).Build().Run();
         }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder
+                        // Make sure Kestrel listens on the correct port.
+                        .UseScalewayFunctionsHosting()
+                        .UseStartup<Startup>();
+                });
     }
+}
+```
 
 Second, your `Startup` class must be amended, adding required services to your service provider and adding the actual middleware to the ASP.NET Core pipeline. The required services are added with a call to `AddScalewayServices()` and the middleware is added to the pipeline with a call to `UseScalewayServices()`. Since the middleware performs authroziation, it is essential that the middleware is added as early as possible in the pipeline. A sample `Startup` class might look like
 
-    using System;
-    using Hellang.Middleware.ProblemDetails;
-    using Microsoft.AspNetCore.Builder;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Hosting;
+```cs
+using System;
+using Hellang.Middleware.ProblemDetails;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
-    namespace Scaleway.Functions
+namespace Scaleway.Functions
+{
+    public class Startup
     {
-        public class Startup
+        public void ConfigureServices(IServiceCollection services)
         {
-            public void ConfigureServices(IServiceCollection services)
-            {
-                services.AddControllers();
-                services
-                    .AddResponseCompression()
-                    .AddProblemDetails()
-                    // Add the services required by the Scaleway.Functions middleware.
-                    .AddScalewayFunctions()
-                    .AddApplicationInsightsTelemetry();
-            }
+            services.AddControllers();
+            services
+                .AddResponseCompression()
+                .AddProblemDetails()
+                // Add the services required by the Scaleway.Functions middleware.
+                .AddScalewayFunctions()
+                .AddApplicationInsightsTelemetry();
+        }
 
-            public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            app
+                .UseProblemDetails()
+                // Add the Scaleway.Functions middleware as early as possible in the pipeline.
+                .UseScalewayFunctions(new Uri("https://sample-bucket-website.s3-website.nl-ams.scw.cloud/"))
+                .UseResponseCompression()
+                .UseHsts()
+                .UseHttpsRedirection();
+            if (env.IsDevelopment())
             {
-                app
-                    .UseProblemDetails()
-                    // Add the Scaleway.Functions middleware as early as possible in the pipeline.
-                    .UseScalewayFunctions(new Uri("https://sample-bucket-website.s3-website.nl-ams.scw.cloud/"))
-                    .UseResponseCompression()
-                    .UseHsts()
-                    .UseHttpsRedirection();
-                if (env.IsDevelopment())
-                {
-                    app.UseDeveloperExceptionPage();
-                }
-                app
-                    .UseRouting()
-                    .UseEndpoints(endpoints => endpoints.MapControllers());
+                app.UseDeveloperExceptionPage();
             }
+            app
+                .UseRouting()
+                .UseEndpoints(endpoints => endpoints.MapControllers());
         }
     }
+}
+```
 
 As you can see in the sample above, it is possible to add one or more URIs, which will be added to the `Access-Control-Allow-Origin` header in the function's responses. This might come in handy if you use the function as an API backend for a Scaleway bucket website, for example.


### PR DESCRIPTION
Hi ! Just a simple aesthetic improvement 🙂

(The diff is bit messy but I just replaced the indented code blocks by the ` ```cs` syntax)